### PR TITLE
chore: provide pyrightconfig for uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,4 +209,3 @@ __marimo__/
 mcp_config.json
 # LSP 캐시 제외
 .pyright_cache/
-pyrightconfig.json

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/pyright/main/packages/pyright/schema/pyrightconfig.schema.json",
+  "include": ["src"],
+  "exclude": [
+    "**/node_modules",
+    "**/__pycache__",
+    "src/experimental",
+    "src/typestubs",
+    ".venv",
+    ".git"
+  ],
+  "venvPath": ".",
+  "venv": ".venv",
+  "reportMissingImports": "error",
+  "reportMissingTypeStubs": false,
+  "reportIncompatibleMethodOverride": "error",
+  "reportIncompatibleVariableOverride": "error",
+  "reportImplicitOverride": "warning"
+}


### PR DESCRIPTION
## Summary
- allow `pyrightconfig.json` to be tracked
- add `pyrightconfig.json` pointing Pyright at the uv-managed `.venv`

## Testing
- `ruff check .`
- `pyright`


------
https://chatgpt.com/codex/tasks/task_e_68a6905f3ad88332a17d1bd6dc15897d