### PR TITLE
Add pytest config and comprehensive module tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,14 @@ reportImplicitOverride = "warning"
 venvPath = "."
 venv = ".venv"
 
+
+[project.optional-dependencies]
+test = [
+  "pytest>=8.0",
+  "pytest-asyncio>=0.23",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,3 +22,60 @@ sys.modules.setdefault(
     "strands.session.file_session_manager",
     SimpleNamespace(FileSessionManager=DummyFileSessionManager),
 )
+
+# Stub out external dependencies used by adapters
+sys.modules.setdefault("boto3", SimpleNamespace(client=lambda *args, **kwargs: None))
+
+class _DummyStructlog(SimpleNamespace):
+    def __init__(self):
+        processors = SimpleNamespace(
+            add_log_level=None,
+            TimeStamper=lambda fmt=None: None,
+            StackInfoRenderer=lambda: None,
+            format_exc_info=None,
+            UnicodeDecoder=None,
+            dict_tracebacks=None,
+            JSONRenderer=lambda: None,
+        )
+        dev = SimpleNamespace(
+            set_exc_info=None,
+            ConsoleRenderer=lambda colors=True: None,
+        )
+
+        super().__init__(
+            processors=processors,
+            dev=dev,
+            configure=lambda **kwargs: None,
+            PrintLoggerFactory=lambda: None,
+            BoundLogger=object,
+            get_logger=lambda name=None: SimpleNamespace(),
+        )
+
+
+sys.modules.setdefault("structlog", _DummyStructlog())
+
+# Additional stubs for optional dependencies
+sys.modules.setdefault("strands", SimpleNamespace(Agent=object))
+sys.modules.setdefault("strands.hooks", SimpleNamespace(HookProvider=object))
+sys.modules.setdefault("dotenv", SimpleNamespace(load_dotenv=lambda *args, **kwargs: None))
+sys.modules.setdefault(
+    "utils.logger",
+    SimpleNamespace(
+        logger=SimpleNamespace(
+            info=lambda *args, **kwargs: None,
+            error=lambda *args, **kwargs: None,
+            warning=lambda *args, **kwargs: None,
+        )
+    ),
+)
+
+# Stub primary router to avoid importing DI container and secondary adapters
+sys.modules.setdefault("adapters.primary.router", SimpleNamespace(create_api_router=lambda *args, **kwargs: None))
+
+# Ensure ulid module provides callable ulid() helper
+try:
+    import ulid as _ulid  # type: ignore
+    if not callable(getattr(_ulid, "ulid", None)):
+        _ulid.ulid = _ulid.new  # type: ignore[attr-defined]
+except Exception:
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from types import SimpleNamespace
+
+os.environ.setdefault("MODEL_ID", "test-model")
+os.environ.setdefault("ENVIRONMENT", "test")
+
+class DummyRepositorySessionManager:
+    def __init__(self, session_id: str, **kwargs):
+        self.session_id = session_id
+
+class DummyFileSessionManager(DummyRepositorySessionManager):
+    def __init__(self, session_id: str, storage_dir: str, **kwargs):
+        super().__init__(session_id, **kwargs)
+        self.storage_dir = storage_dir
+
+sys.modules.setdefault(
+    "strands.session.repository_session_manager",
+    SimpleNamespace(RepositorySessionManager=DummyRepositorySessionManager),
+)
+sys.modules.setdefault(
+    "strands.session.file_session_manager",
+    SimpleNamespace(FileSessionManager=DummyFileSessionManager),
+)

--- a/tests/test_chat_controller.py
+++ b/tests/test_chat_controller.py
@@ -3,37 +3,83 @@ from fastapi.testclient import TestClient
 import pytest
 
 from adapters.primary.chat.chat_controller import ChatController
+from services.chat.chat_service import ChatService
+from ports.session.session_adapter import SessionAdapter
+from ports.chat.mcp_agent_adapter import MCPAgentAdapter
 
 
-class DummyChatService:
-    async def generate_response(self, session_id: str, message: str, stream: bool = False):
-        if stream:
-            async def iterator():
-                yield {"data": "chunk"}
-            return iterator()
+class DummySessionAdapter(SessionAdapter):
+    async def create_session(self, user_id: str) -> str:
+        return "1"
+
+    async def get_session(self, session_id: str):
+        from conftest import DummyRepositorySessionManager
+        return DummyRepositorySessionManager(session_id)
+
+    async def delete_session(self, session_id: str) -> None:
+        pass
+
+    def cleanup(self) -> None:
+        pass
+
+
+class DummyAgentAdapter(MCPAgentAdapter):
+    async def generate_response(self, session_manager, content: str) -> str:
         return "response"
 
+    async def generate_response_stream(self, session_manager, content: str):
+        async def iterator():
+            yield {"data": "chunk"}
+        return iterator()
 
-def create_app():
+    def configure_mcp(self, mcp_config=None) -> None:
+        pass
+
+    def cleanup(self) -> None:
+        pass
+
+
+class FailingAgentAdapter(DummyAgentAdapter):
+    async def generate_response(self, session_manager, content: str) -> str:
+        raise RuntimeError("boom")
+
+
+@pytest.fixture
+def app():
+    service = ChatService(DummyAgentAdapter(), DummySessionAdapter())
+    controller = ChatController(service)
     app = FastAPI()
-    controller = ChatController(DummyChatService())
     app.include_router(controller.router)
     return app
 
 
-def test_invoke_non_streaming():
-    app = create_app()
+def test_invoke_non_streaming(app):
     client = TestClient(app)
     resp = client.post("/v1/invocations", json={"message": "hi", "session_id": "1"})
     assert resp.status_code == 200
     assert resp.json() == {"data": "response"}
 
 
-def test_invoke_streaming():
-    app = create_app()
+def test_invoke_streaming(app):
     client = TestClient(app)
     with client.stream("POST", "/v1/invocations", json={"message": "hi", "session_id": "1", "stream": True}) as resp:
         assert resp.status_code == 200
         assert resp.headers["content-type"].startswith("text/event-stream")
         body = b"".join(resp.iter_bytes())
         assert b"chunk" in body
+
+
+def test_invoke_requires_fields(app):
+    client = TestClient(app)
+    resp = client.post("/v1/invocations", json={"message": "hi"})
+    assert resp.status_code == 422
+
+
+def test_invoke_service_error():
+    service = ChatService(FailingAgentAdapter(), DummySessionAdapter())
+    controller = ChatController(service)
+    fastapi_app = FastAPI()
+    fastapi_app.include_router(controller.router)
+    client = TestClient(fastapi_app, raise_server_exceptions=False)
+    resp = client.post("/v1/invocations", json={"message": "hi", "session_id": "1"})
+    assert resp.status_code == 500

--- a/tests/test_chat_controller.py
+++ b/tests/test_chat_controller.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from adapters.primary.chat.chat_controller import ChatController
+
+
+class DummyChatService:
+    async def generate_response(self, session_id: str, message: str, stream: bool = False):
+        if stream:
+            async def iterator():
+                yield {"data": "chunk"}
+            return iterator()
+        return "response"
+
+
+def create_app():
+    app = FastAPI()
+    controller = ChatController(DummyChatService())
+    app.include_router(controller.router)
+    return app
+
+
+def test_invoke_non_streaming():
+    app = create_app()
+    client = TestClient(app)
+    resp = client.post("/v1/invocations", json={"message": "hi", "session_id": "1"})
+    assert resp.status_code == 200
+    assert resp.json() == {"data": "response"}
+
+
+def test_invoke_streaming():
+    app = create_app()
+    client = TestClient(app)
+    with client.stream("POST", "/v1/invocations", json={"message": "hi", "session_id": "1", "stream": True}) as resp:
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        body = b"".join(resp.iter_bytes())
+        assert b"chunk" in body

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -1,0 +1,55 @@
+import pytest
+from typing import AsyncIterator, Any
+
+from services.chat.chat_service import ChatService
+from ports.chat.mcp_agent_adapter import MCPAgentAdapter
+from ports.session.session_adapter import SessionAdapter
+
+
+class DummyAgentAdapter(MCPAgentAdapter):
+    async def generate_response(self, session_manager, content: str) -> str:
+        return f"echo: {content}"
+
+    async def generate_response_stream(self, session_manager, content: str) -> AsyncIterator[Any]:
+        async def iterator():
+            yield {"data": "first"}
+            yield {"data": "second"}
+        return iterator()
+
+    def configure_mcp(self, mcp_config=None) -> None:
+        pass
+
+    def cleanup(self) -> None:
+        pass
+
+
+class DummySessionAdapter(SessionAdapter):
+    async def create_session(self, user_id: str) -> str:
+        return "session"
+
+    async def get_session(self, session_id: str):
+        class DummySession:
+            def __init__(self, session_id: str):
+                self.session_id = session_id
+        return DummySession(session_id)
+
+    async def delete_session(self, session_id: str) -> None:
+        pass
+
+    def cleanup(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_generate_response_non_stream():
+    service = ChatService(DummyAgentAdapter(), DummySessionAdapter())
+    result = await service.generate_response("session", "hello", stream=False)
+    assert result == "echo: hello"
+
+
+@pytest.mark.asyncio
+async def test_generate_response_stream():
+    service = ChatService(DummyAgentAdapter(), DummySessionAdapter())
+    stream = await service.generate_response("session", "hello", stream=True)
+    chunks = [chunk async for chunk in stream]
+    assert chunks == [{"data": "first"}, {"data": "second"}]

--- a/tests/test_ping_controller.py
+++ b/tests/test_ping_controller.py
@@ -4,12 +4,21 @@ from fastapi.testclient import TestClient
 from adapters.primary.ping.ping_controller import PingController
 
 
-def test_ping_controller_returns_ok():
-    controller = PingController()
+def create_app():
     app = FastAPI()
+    controller = PingController()
     app.include_router(controller.router)
-    client = TestClient(app)
+    return app
 
+
+def test_ping_controller_returns_ok():
+    client = TestClient(create_app())
     response = client.get("/ping")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_ping_controller_disallows_post():
+    client = TestClient(create_app())
+    response = client.post("/ping")
+    assert response.status_code == 405

--- a/tests/test_ping_controller.py
+++ b/tests/test_ping_controller.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from adapters.primary.ping.ping_controller import PingController
+
+
+def test_ping_controller_returns_ok():
+    controller = PingController()
+    app = FastAPI()
+    app.include_router(controller.router)
+    client = TestClient(app)
+
+    response = client.get("/ping")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/tests/test_session_controller.py
+++ b/tests/test_session_controller.py
@@ -1,0 +1,81 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from adapters.primary.session.session_controller import SessionController
+from services.session.session_service import SessionService
+from ports.session.session_adapter import SessionAdapter
+
+
+class InMemorySessionAdapter(SessionAdapter):
+    def __init__(self):
+        self.sessions = {}
+
+    async def create_session(self, user_id: str) -> str:
+        session_id = f"s{len(self.sessions) + 1}"
+        self.sessions[session_id] = user_id
+        return session_id
+
+    async def get_session(self, session_id: str):
+        from conftest import DummyRepositorySessionManager
+        if session_id not in self.sessions:
+            raise KeyError(session_id)
+        return DummyRepositorySessionManager(session_id)
+
+    async def delete_session(self, session_id: str) -> None:
+        if session_id not in self.sessions:
+            raise KeyError(session_id)
+        del self.sessions[session_id]
+
+    def cleanup(self) -> None:
+        pass
+
+
+@pytest.fixture
+def app():
+    adapter = InMemorySessionAdapter()
+    service = SessionService(adapter)
+    controller = SessionController(service)
+    app = FastAPI()
+    app.include_router(controller.router)
+    return app, adapter
+
+
+def test_create_session(app):
+    fastapi_app, adapter = app
+    client = TestClient(fastapi_app)
+    resp = client.post("/v1/sessions", json={"user_id": "u1"})
+    assert resp.status_code == 200
+    session_id = resp.json()["session_id"]
+    assert session_id in adapter.sessions
+
+
+def test_create_session_requires_user_id(app):
+    fastapi_app, _ = app
+    client = TestClient(fastapi_app)
+    resp = client.post("/v1/sessions", json={})
+    assert resp.status_code == 422
+
+
+def test_delete_session(app):
+    fastapi_app, adapter = app
+    adapter.sessions["s1"] = "u1"
+    client = TestClient(fastapi_app)
+    resp = client.request("DELETE", "/v1/sessions", json={"session_id": "s1"})
+    assert resp.status_code == 200
+    assert resp.json() == {"message": "Session deleted"}
+    assert "s1" not in adapter.sessions
+
+
+def test_delete_session_requires_id(app):
+    fastapi_app, _ = app
+    client = TestClient(fastapi_app)
+    resp = client.request("DELETE", "/v1/sessions", json={})
+    assert resp.status_code == 422
+
+
+def test_delete_session_not_found(app):
+    fastapi_app, _ = app
+    client = TestClient(fastapi_app, raise_server_exceptions=False)
+    resp = client.request("DELETE", "/v1/sessions", json={"session_id": "missing"})
+    assert resp.status_code == 500

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -1,0 +1,18 @@
+import pytest
+
+from services.session.session_service import SessionService
+from adapters.secondary.session.strands_file_session_adapter import StrandsFileSessionAdapter
+
+
+@pytest.mark.asyncio
+async def test_session_service_lifecycle(tmp_path):
+    adapter = StrandsFileSessionAdapter(base_path=str(tmp_path))
+    service = SessionService(adapter)
+
+    session_id = await service.create_session("user1")
+    session = await service.get_session(session_id)
+    assert session.session_id == session_id
+
+    await service.delete_session(session_id)
+    with pytest.raises(KeyError):
+        await service.get_session(session_id)

--- a/tests/test_strands_file_session_adapter.py
+++ b/tests/test_strands_file_session_adapter.py
@@ -1,0 +1,16 @@
+import pytest
+
+from adapters.secondary.session.strands_file_session_adapter import StrandsFileSessionAdapter
+
+
+@pytest.mark.asyncio
+async def test_create_get_delete_session(tmp_path):
+    adapter = StrandsFileSessionAdapter(base_path=str(tmp_path))
+
+    session_id = await adapter.create_session("user1")
+    session = await adapter.get_session(session_id)
+    assert session.session_id == session_id
+
+    await adapter.delete_session(session_id)
+    with pytest.raises(KeyError):
+        await adapter.get_session(session_id)


### PR DESCRIPTION
## Summary
- configure pytest and async test support in `pyproject.toml`
- add unit tests for ping controller, session management, chat service, and chat controller
- provide stubs for external `strands` dependencies for isolated testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7e0866aec83328d24f3cb46229f01